### PR TITLE
Upgrade to Bean Validation 2.0

### DIFF
--- a/jsimpledb-main/pom.xml
+++ b/jsimpledb-main/pom.xml
@@ -65,13 +65,13 @@
             <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <optional>false</optional>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
             <optional>false</optional>
         </dependency>
         <dependency>

--- a/jsimpledb-maven-plugin/pom.xml
+++ b/jsimpledb-maven-plugin/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.4</version>
+            <version>3.5</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.4</version>
+                <version>3.5</version>
                 <executions>
                     <execution>
                         <id>default-descriptor</id>

--- a/jsimpledb-test/pom.xml
+++ b/jsimpledb-test/pom.xml
@@ -37,13 +37,13 @@
             <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <optional>false</optional>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
             <optional>false</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
         <google-cloud-java.version>0.11.1</google-cloud-java.version>
         <guava.version>21.0</guava.version>
         <hawtjni.version>1.14</hawtjni.version>
-        <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
-        <javax.el-api.version>2.2.5</javax.el-api.version>
+        <hibernate-validator.version>6.0.2.Final</hibernate-validator.version>
+        <javax.el.version>3.0.1-b08</javax.el.version>
         <javax.mail.version>1.5.6</javax.mail.version>
         <jetty.version>9.2.19.v20160908</jetty.version>
         <jline.version>2.14.2</jline.version>
@@ -105,7 +105,7 @@
         <mssql.version>6.1.0.jre8</mssql.version>
         <mysql.version>6.0.6</mysql.version>
         <nvt4j.version>1.2.0</nvt4j.version>
-        <plugin-api.version>3.3.9</plugin-api.version>
+        <plugin-api.version>3.5.0</plugin-api.version>
         <postgresql.version>9.4.1211.jre7</postgresql.version>
         <rocksdb.version>4.11.2</rocksdb.version>
         <servlet-api.version>3.1.0</servlet-api.version>
@@ -114,7 +114,7 @@
         <sqlite.version>3.16.1</sqlite.version>
         <testng.version>6.9.10</testng.version>
         <vaadin7.version>7.7.3</vaadin7.version>
-        <validation-api.version>1.1.0.Final</validation-api.version>
+        <validation-api.version>2.0.0.Final</validation-api.version>
 
     </properties>
 
@@ -335,15 +335,15 @@
                 <version>${validation-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator.version}</version>
                 <optional>true</optional>
             </dependency>
             <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
-                <version>${javax.el-api.version}</version>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.el</artifactId>
+                <version>${javax.el.version}</version>
                 <optional>true</optional>
             </dependency>
 


### PR DESCRIPTION
Also upgrade Maven plugins that were old and couldn't handle Java 8 annotations.

Bean Validation 2 adds a bunch of nice new features like `@Positive` on integer fields.